### PR TITLE
Added plugin status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,
 |-------------------------------|-----------------------|---------------------------------------------------------------------|----------|--------------------- | 
 | dummy                         | 9,500,000 - 9,500,999 | https://github.com/coreruleset/dummy-plugin                         | official | -                    | 
 | auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official | untested             | 
-| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official | untested             | 
-| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official | untested             | 
-| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official | untested             | 
-| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official | untested             | 
+| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official | &#9989; tested       | 
+| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official | &#9989; tested       | 
+| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official | &#9989; tested       | 
+| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official | &#9989; tested       | 
 | drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official | unreleased, untested |
-| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official | untested             |
+| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official | &#9989; tested       |
 | nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official | unreleased, untested |
 | dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official | unreleased, untested |
 | cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official | unreleased, untested |
 | xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official | unreleased, untested |
-| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official | untested             |
-| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official | untested             |
+| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official | &#9989; tested       |
+| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official | being tested         |
 | dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official | unreleased, untested |
 | dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official | draft                |
 | incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official | -                    |

--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@ place to register plugins and reserve rule ID ranges.
 The rule ID range from 9,500,000 - 9,999,999 is reserved for CRS plugins.
 
 Plugins usually get a range of 1,000 IDs with the notable exception of the incubator plugin that
-maps the regular CRS IDs from the 900K to the 9.9M range.
+maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,999.
 
-| *Plugin Name*                 | *Rule ID Range*       | *Repository*                                                        | *Type*   |
-|-------------------------------|-----------------------|---------------------------------------------------------------------|----------|
-| dummy                         | 9,500,000 - 9,500,999 | https://github.com/coreruleset/dummy-plugin                         | official |
-| auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official |
-| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official |
-| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official |
-| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official |
-| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official |
-| drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official |
-| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official |
-| nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official |
-| dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official |
-| cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official |
-| xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official |
-| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official |
-| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official |
-| dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official |
-| dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official |
-| incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official |
+| *Plugin Name*                 | *Rule ID Range*       | *Repository*                                                        | *Type*   | *Status*             |
+|-------------------------------|-----------------------|---------------------------------------------------------------------|----------|--------------------- | 
+| dummy                         | 9,500,000 - 9,500,999 | https://github.com/coreruleset/dummy-plugin                         | official | -                    | 
+| auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official | untested             | 
+| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official | untested             | 
+| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official | untested             | 
+| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official | untested             | 
+| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official | untested             | 
+| drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official | unreleased, untested |
+| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official | untested             |
+| nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official | unreleased, untested |
+| dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official | unreleased, untested |
+| cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official | unreleased, untested |
+| xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official | unreleased, untested |
+| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official | untested             |
+| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official | untested             |
+| dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official | unreleased, untested |
+| dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official | draft                |
+| incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official | -                    |


### PR DESCRIPTION
Note: the "unreleased" status pertains to those repos currently being private.
Another note: I don't know which plugins have been tested, so currently they all are labelled untested for now.