### PR TITLE
add 3rd party RoundCube, SOGo and iRedAdmin Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ The rule ID range from 9,500,000 - 9,999,999 is reserved for CRS plugins.
 Plugins usually get a range of 1,000 IDs with the notable exception of the incubator plugin that
 maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,999.
 
-| *Plugin Name*                 | *Rule ID Range*       | *Repository*                                                        | *Type*   | *Status*             | *CI* |
-|-------------------------------|-----------------------|---------------------------------------------------------------------|----------|--------------------- | -----|
-| template                      | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                      | official  | tested               | [![.github/workflows/integration.yml](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg)](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
-| auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official  | untested             | |
-| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official  | &#9989;&nbsp;tested  | |
-| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official  | &#9989;&nbsp;tested  | |
-| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official  | &#9989;&nbsp;tested  | |
-| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official  | &#9989;&nbsp;tested  | |
-| drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official  | untested             | |
-| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official  | &#9989;&nbsp;tested  | |
-| nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official  | untested             | |
-| dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official  | untested             | |
-| cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official  | untested             | |
-| xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official  | &#9989;&nbsp;tested  | |
-| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official  | &#9989;&nbsp;tested  | |
-| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official  | being tested         | |
-| iRedMail-rule-exclusions-plugin    | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin           | 3rd party | &#9989;&nbsp;tested  | |
-| dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official  | untested             | |
-| dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official  | draft                | |
-| machine-learning-integration-plugin | 9,516,000 - 9,516,999 | https://github.com/coreruleset/machine-learning-integration-plugin | official | draft                | |
-| performance-plugin            | 9,517,000 - 9,517,999 | https://github.com/coreruleset/performance-plugin                   | official  | draft                | |
-| incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official  | -                    | |
+| *Plugin Name*                       | *Rule ID Range*       | *Repository*                                                        | *Type*    | *Status*             | *CI* |
+|-------------------------------------|-----------------------|---------------------------------------------------------------------|-----------|----------------------| -----|
+| template                            | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                      | official  | tested               | [![.github/workflows/integration.yml](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg)](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
+| auto-decoding                       | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official  | untested             | |
+| antivirus                           | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official  | &#9989;&nbsp;tested  | |
+| body-decompress                     | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official  | &#9989;&nbsp;tested  | |
+| fake-bot                            | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official  | &#9989;&nbsp;tested  | |
+| google-oauth2                       | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official  | &#9989;&nbsp;tested  | |
+| drupal-rule-exclusions              | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official  | untested             | |
+| wordpress-rule-exclusions           | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official  | &#9989;&nbsp;tested  | |
+| nextcloud-rule-exclusions           | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official  | untested             | |
+| dokuwiki-rule-exclusions            | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official  | untested             | |
+| cpanel-rule-exclusions              | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official  | untested             | |
+| xenforo-rule-exclusions             | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official  | &#9989;&nbsp;tested  | |
+| phpbb-rule-exclusions               | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official  | &#9989;&nbsp;tested  | |
+| phpmyadmin-rule-exclusions          | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official  | being tested         | |
+| dos-protection-modsecurity-v2       | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official  | untested             | |
+| dos-protection-modsecurity-v3       | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official  | draft                | |
+| machine-learning-integration-plugin | 9,516,000 - 9,516,999 | https://github.com/coreruleset/machine-learning-integration-plugin  | official  | draft                | |
+| performance-plugin                  | 9,517,000 - 9,517,999 | https://github.com/coreruleset/performance-plugin                   | official  | draft                | |
+| iRedMail-rule-exclusions-plugin     | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin           | 3rd party | &#9989;&nbsp;tested  | |
+| incubator                           | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official  | -                    | |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,
 
 | *Plugin Name*                       | *Rule ID Range*       | *Repository*                                                             | *Type*    | *Status*            | *CI* |
 |-------------------------------------|-----------------------|--------------------------------------------------------------------------|-----------|---------------------| -----|
-| template                            | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                           | official  | tested              | [<img src="https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg" alt=".github/workflows/integration.yml" width="300" />](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
+| template                            | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                           | official  | &#9989;&nbsp;tested        | [<img src="https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg" alt=".github/workflows/integration.yml" width="300" />](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
 | auto-decoding                       | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                      | official  | untested            |      |
 | antivirus                           | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                          | official  | &#9989;&nbsp;tested |      |
 | body-decompress                     | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin                    | official  | &#9989;&nbsp;tested |      |
@@ -29,5 +29,7 @@ maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,
 | dos-protection-modsecurity-v3       | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3      | official  | draft               |      |
 | machine-learning-integration-plugin | 9,516,000 - 9,516,999 | https://github.com/coreruleset/machine-learning-integration-plugin       | official  | draft               |      |
 | performance-plugin                  | 9,517,000 - 9,517,999 | https://github.com/coreruleset/performance-plugin                        | official  | draft               |      |
-| iRedMail-rule-exclusions-plugin     | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin                | 3rd party | &#9989;&nbsp;tested |      |
+| iredadmin-rule-exclusions-plugin    | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iredadmin-rule-exclusions-plugin          | 3rd party | &#9989;&nbsp;tested |      |
+| roundcube-rule-exclusions-plugin    | 9,519,000 - 9,519,999 | https://github.com/EsadCetiner/roundcube-rule-exclusions-plugin          | 3rd party | &#9989;&nbsp;tested |      |
+| sogo-rule-exclusions-plugin         | 9,520,000 - 9,520,999 | https://github.com/EsadCetiner/sogo-rule-exclusions-plugin               | 3rd party | &#9989;&nbsp;tested |      |
 | incubator                           | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                          | official  | -                   |      |

--- a/README.md
+++ b/README.md
@@ -11,22 +11,23 @@ maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,
 
 | *Plugin Name*                 | *Rule ID Range*       | *Repository*                                                        | *Type*   | *Status*             | *CI* |
 |-------------------------------|-----------------------|---------------------------------------------------------------------|----------|--------------------- | -----|
-| template                      | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                      | official | tested               | [![.github/workflows/integration.yml](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg)](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
-| auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official | untested             | |
-| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official | &#9989;&nbsp;tested  | |
-| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official | &#9989;&nbsp;tested  | |
-| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official | &#9989;&nbsp;tested  | |
-| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official | &#9989;&nbsp;tested  | |
-| drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official | untested             | |
-| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official | &#9989;&nbsp;tested  | |
-| nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official | untested             | |
-| dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official | untested             | |
-| cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official | untested             | |
-| xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official | &#9989;&nbsp;tested  | |
-| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official | &#9989;&nbsp;tested  | |
-| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official | being tested         | |
-| dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official | untested             | |
-| dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official | draft                | |
+| template                      | 9,500,000 - 9,500,999 | https://github.com/coreruleset/template-plugin                      | official  | tested               | [![.github/workflows/integration.yml](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml/badge.svg)](https://github.com/coreruleset/template-plugin/actions/workflows/integration.yml) |
+| auto-decoding                 | 9,501,000 - 9,501,999 | https://github.com/coreruleset/auto-decoding-plugin                 | official  | untested             | |
+| antivirus                     | 9,502,000 - 9,502,999 | https://github.com/coreruleset/antivirus-plugin                     | official  | &#9989;&nbsp;tested  | |
+| body-decompress               | 9,503,000 - 9,503,999 | https://github.com/coreruleset/body-decompress-plugin               | official  | &#9989;&nbsp;tested  | |
+| fake-bot                      | 9,504,000 - 9,504,999 | https://github.com/coreruleset/fake-bot-plugin                      | official  | &#9989;&nbsp;tested  | |
+| google-oauth2                 | 9,505,000 - 9,505,999 | https://github.com/coreruleset/google-oauth2-plugin                 | official  | &#9989;&nbsp;tested  | |
+| drupal-rule-exclusions        | 9,506,000 - 9,506,999 | https://github.com/coreruleset/drupal-rule-exclusions-plugin        | official  | untested             | |
+| wordpress-rule-exclusions     | 9,507,000 - 9,507,999 | https://github.com/coreruleset/wordpress-rule-exclusions-plugin     | official  | &#9989;&nbsp;tested  | |
+| nextcloud-rule-exclusions     | 9,508,000 - 9,508,999 | https://github.com/coreruleset/nextcloud-rule-exclusions-plugin     | official  | untested             | |
+| dokuwiki-rule-exclusions      | 9,509,000 - 9,509,999 | https://github.com/coreruleset/dokuwiki-rule-exclusions-plugin      | official  | untested             | |
+| cpanel-rule-exclusions        | 9,510,000 - 9,510,999 | https://github.com/coreruleset/cpanel-rule-exclusions-plugin        | official  | untested             | |
+| xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official  | &#9989;&nbsp;tested  | |
+| phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official  | &#9989;&nbsp;tested  | |
+| phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official  | being tested         | |
+| iRedMail-exclusions-plugin    | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin           | 3rd party | &#9989;&nbsp;tested  | |
+| dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official  | untested             | |
+| dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official  | draft                | |
 | machine-learning-integration-plugin | 9,516,000 - 9,516,999 | https://github.com/coreruleset/machine-learning-integration-plugin | official | draft                | |
-| performance-plugin            | 9,517,000 - 9,517,999 | https://github.com/coreruleset/performance-plugin                   | official | draft                | |
-| incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official | -                    | |
+| performance-plugin            | 9,517,000 - 9,517,999 | https://github.com/coreruleset/performance-plugin                   | official  | draft                | |
+| incubator                     | 9,900,000 - 9,999,999 | https://github.com/coreruleset/incubator-plugin                     | official  | -                    | |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ maps the regular CRS IDs from 900K for each rule to the range 9,900,000 - 9,999,
 | xenforo-rule-exclusions       | 9,511,000 - 9,511,999 | https://github.com/coreruleset/xenforo-rule-exclusions-plugin       | official  | &#9989;&nbsp;tested  | |
 | phpbb-rule-exclusions         | 9,512,000 - 9,512,999 | https://github.com/coreruleset/phpbb-rule-exclusions-plugin         | official  | &#9989;&nbsp;tested  | |
 | phpmyadmin-rule-exclusions    | 9,513,000 - 9,513,999 | https://github.com/coreruleset/phpmyadmin-rule-exclusions-plugin    | official  | being tested         | |
-| iRedMail-exclusions-plugin    | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin           | 3rd party | &#9989;&nbsp;tested  | |
+| iRedMail-rule-exclusions-plugin    | 9,518,000 - 9,518,999 | https://github.com/EsadCetiner/iRedMail-exclusions-plugin           | 3rd party | &#9989;&nbsp;tested  | |
 | dos-protection-modsecurity-v2 | 9,514,000 - 9,514,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v2 | official  | untested             | |
 | dos-protection-modsecurity-v3 | 9,515,000 - 9,515,999 | https://github.com/coreruleset/dos-protection-plugin-modsecurity-v3 | official  | draft                | |
 | machine-learning-integration-plugin | 9,516,000 - 9,516,999 | https://github.com/coreruleset/machine-learning-integration-plugin | official | draft                | |


### PR DESCRIPTION
This pull requests adds a 3rd party plugin to fix false positives with iRedMail, for now this plugin only supports Roundcube Webmail with iRedAdmin open source edition. I've taken the 9518xxx rule range, let me know if you want me to use a different rule range.